### PR TITLE
Fix wav decoder with mono-channel

### DIFF
--- a/src/js/worker-decoder-wav.js
+++ b/src/js/worker-decoder-wav.js
@@ -7,11 +7,7 @@ self.onmessage = event => {
     const decoded = decoder.decodeChunkSync(event.data.decode);
     self.postMessage(
       { decoded, sessionId },
-      [
-        decoded.channelData[0].buffer,
-        decoded.channelData[1].buffer
-      ]
+      decoded.channelData.map(({ buffer }) => buffer)
     );
   }
 };
-


### PR DESCRIPTION
## Problem

It breaks when it tries to stream a wav with only one channel with the following error:

```
worker-decoder-wav.js:12 Uncaught TypeError: Cannot read properties of undefined (reading 'buffer')
    at self.onmessage (worker-decoder-wav.js:12:32)
```

because `channelData` would only have one item

## Solution

By using `.map()` to iteration through each channel and obtain the buffer, it can now accommodate for an arbitrary amount of channels other than two.